### PR TITLE
Add realm attribute to WWW-Authenticate header.

### DIFF
--- a/src/Http/Middleware/VeryBasicAuth.php
+++ b/src/Http/Middleware/VeryBasicAuth.php
@@ -20,7 +20,7 @@ class VeryBasicAuth
         if(in_array('*', $config['envs']) || in_array(app()->environment(), $config['envs'])) {
             if($request->getUser() != $config['user'] || $request->getPassword() != $config['password']) {
 
-                $header = ['WWW-Authenticate' => 'Basic'];
+                $header = ['WWW-Authenticate' => 'Basic realm="' . $config['realm'] . '"'];
 
                 // If view is available
                 if (isset($config['error_view'])) {

--- a/src/Http/Middleware/VeryBasicAuth.php
+++ b/src/Http/Middleware/VeryBasicAuth.php
@@ -20,6 +20,10 @@ class VeryBasicAuth
         if(in_array('*', $config['envs']) || in_array(app()->environment(), $config['envs'])) {
             if($request->getUser() != $config['user'] || $request->getPassword() != $config['password']) {
 
+                if (!isset($config['realm'])) {
+                    $config['realm'] = 'Basic Auth';
+                }
+
                 $header = ['WWW-Authenticate' => 'Basic realm="' . $config['realm'] . '"'];
 
                 // If view is available

--- a/src/config.stub
+++ b/src/config.stub
@@ -18,6 +18,9 @@
         // Message to display if the user "opts out"/clicks "cancel"
         'error_message'     => 'You have to supply your credentials to access this resource.',
 
+        // Message to display in Auth Dialog.
+        'realm'             => 'Basic Auth',
+
         // If you prefer to use a view with your error message you can uncomment "error_view".
         // This will superseed your default response message
         // 'error_view'        => 'very_basic_auth::default'

--- a/tests/VeryBasicAuthTests.php
+++ b/tests/VeryBasicAuthTests.php
@@ -51,7 +51,7 @@ class VeryBasicAuthTests extends \Orchestra\Testbench\TestCase {
 
         $result = $this->middleware->handle($request, $next);
 
-        $realm = config('very_basic_auth.realm');
+        $realm = config('very_basic_auth.realm', 'Basic Auth');
 
 		$this->assertEquals('Basic realm="' . $realm . '"', $result->headers->get('www-authenticate'));
 		$this->assertEquals(401, $result->getStatusCode());
@@ -76,7 +76,7 @@ class VeryBasicAuthTests extends \Orchestra\Testbench\TestCase {
 
         $result = $this->middleware->handle($request, $next);
 
-        $realm = config('very_basic_auth.realm');
+        $realm = config('very_basic_auth.realm', 'Basic Auth');
 
         $this->assertEquals('Basic realm="' . $realm . '"', $result->headers->get('www-authenticate'));
 		$this->assertEquals(401, $result->getStatusCode());
@@ -101,7 +101,7 @@ class VeryBasicAuthTests extends \Orchestra\Testbench\TestCase {
 
         $result = $this->middleware->handle($request, $next);
 
-        $realm = config('very_basic_auth.realm');
+        $realm = config('very_basic_auth.realm', 'Basic Auth');
 
         $this->assertEquals('Basic realm="' . $realm . '"', $result->headers->get('www-authenticate'));
 		$this->assertEquals(401, $result->getStatusCode());
@@ -126,7 +126,7 @@ class VeryBasicAuthTests extends \Orchestra\Testbench\TestCase {
 
         $result = $this->middleware->handle($request, $next);
 
-        $realm = config('very_basic_auth.realm');
+        $realm = config('very_basic_auth.realm', 'Basic Auth');
 
         $this->assertEquals('Basic realm="' . $realm . '"', $result->headers->get('www-authenticate'));
 		$this->assertEquals(401, $result->getStatusCode());
@@ -176,7 +176,7 @@ class VeryBasicAuthTests extends \Orchestra\Testbench\TestCase {
 
         $result = $this->middleware->handle($request, $next);
 
-        $realm = config('very_basic_auth.realm');
+        $realm = config('very_basic_auth.realm', 'Basic Auth');
 
         $this->assertEquals('Basic realm="' . $realm . '"', $result->headers->get('www-authenticate'));
 		$this->assertEquals(401, $result->getStatusCode());
@@ -215,7 +215,7 @@ class VeryBasicAuthTests extends \Orchestra\Testbench\TestCase {
 
         $result = $this->middleware->handle($request, $next);
 
-        $realm = config('very_basic_auth.realm');
+        $realm = config('very_basic_auth.realm', 'Basic Auth');
 
         $this->assertEquals('Basic realm="' . $realm . '"', $result->headers->get('www-authenticate'));
 		$this->assertEquals(401, $result->getStatusCode());
@@ -236,7 +236,7 @@ class VeryBasicAuthTests extends \Orchestra\Testbench\TestCase {
 
         $result = $this->middleware->handle($request, $next);
 
-        $realm = config('very_basic_auth.realm');
+        $realm = config('very_basic_auth.realm', 'Basic Auth');
 
         $this->assertEquals('Basic realm="' . $realm . '"', $result->headers->get('www-authenticate'));
 		$this->assertEquals(401, $result->getStatusCode());

--- a/tests/VeryBasicAuthTests.php
+++ b/tests/VeryBasicAuthTests.php
@@ -51,7 +51,9 @@ class VeryBasicAuthTests extends \Orchestra\Testbench\TestCase {
 
         $result = $this->middleware->handle($request, $next);
 
-		$this->assertEquals('Basic', $result->headers->get('www-authenticate'));
+        $realm = config('very_basic_auth.realm');
+
+		$this->assertEquals('Basic realm="' . $realm . '"', $result->headers->get('www-authenticate'));
 		$this->assertEquals(401, $result->getStatusCode());
         $this->assertEquals(config('very_basic_auth.error_message'), $result->getContent());
 	}
@@ -74,7 +76,9 @@ class VeryBasicAuthTests extends \Orchestra\Testbench\TestCase {
 
         $result = $this->middleware->handle($request, $next);
 
-		$this->assertEquals('Basic', $result->headers->get('www-authenticate'));
+        $realm = config('very_basic_auth.realm');
+
+        $this->assertEquals('Basic realm="' . $realm . '"', $result->headers->get('www-authenticate'));
 		$this->assertEquals(401, $result->getStatusCode());
         $this->assertEquals(config('very_basic_auth.error_message'), $result->getContent());
 	}
@@ -97,7 +101,9 @@ class VeryBasicAuthTests extends \Orchestra\Testbench\TestCase {
 
         $result = $this->middleware->handle($request, $next);
 
-		$this->assertEquals('Basic', $result->headers->get('www-authenticate'));
+        $realm = config('very_basic_auth.realm');
+
+        $this->assertEquals('Basic realm="' . $realm . '"', $result->headers->get('www-authenticate'));
 		$this->assertEquals(401, $result->getStatusCode());
         $this->assertEquals(config('very_basic_auth.error_message'), $result->getContent());
 	}
@@ -120,7 +126,9 @@ class VeryBasicAuthTests extends \Orchestra\Testbench\TestCase {
 
         $result = $this->middleware->handle($request, $next);
 
-		$this->assertEquals('Basic', $result->headers->get('www-authenticate'));
+        $realm = config('very_basic_auth.realm');
+
+        $this->assertEquals('Basic realm="' . $realm . '"', $result->headers->get('www-authenticate'));
 		$this->assertEquals(401, $result->getStatusCode());
         $this->assertEquals(config('very_basic_auth.error_message'), $result->getContent());
 	}
@@ -168,7 +176,9 @@ class VeryBasicAuthTests extends \Orchestra\Testbench\TestCase {
 
         $result = $this->middleware->handle($request, $next);
 
-		$this->assertEquals('Basic', $result->headers->get('www-authenticate'));
+        $realm = config('very_basic_auth.realm');
+
+        $this->assertEquals('Basic realm="' . $realm . '"', $result->headers->get('www-authenticate'));
 		$this->assertEquals(401, $result->getStatusCode());
         $this->assertContains('This is the default view for the l5-very-basic-auth-package', $result->getContent());
 	}
@@ -205,7 +215,9 @@ class VeryBasicAuthTests extends \Orchestra\Testbench\TestCase {
 
         $result = $this->middleware->handle($request, $next);
 
-		$this->assertEquals('Basic', $result->headers->get('www-authenticate'));
+        $realm = config('very_basic_auth.realm');
+
+        $this->assertEquals('Basic realm="' . $realm . '"', $result->headers->get('www-authenticate'));
 		$this->assertEquals(401, $result->getStatusCode());
         $this->assertEquals(config('very_basic_auth.error_message'), $result->getContent());
 	}
@@ -224,7 +236,9 @@ class VeryBasicAuthTests extends \Orchestra\Testbench\TestCase {
 
         $result = $this->middleware->handle($request, $next);
 
-		$this->assertEquals('Basic', $result->headers->get('www-authenticate'));
+        $realm = config('very_basic_auth.realm');
+
+        $this->assertEquals('Basic realm="' . $realm . '"', $result->headers->get('www-authenticate'));
 		$this->assertEquals(401, $result->getStatusCode());
         $this->assertEquals(config('very_basic_auth.error_message'), $result->getContent());
 	}


### PR DESCRIPTION
Hi.

Thank you for this great package.
I encountered a problem not remembering authentication with Internet Explorer (version 11).

Internet Explorer probably requires the realm attribute in WWW-Authenticate header.
Without realm attribute, Internet Explorer refuses to remember authentication.