### PR TITLE
Fix stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /vendor
 composer.lock
-src/config.php
 .DS_Store
 .phpunit.result.cache
 phpunit-output

--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ While HTTP Basic Auth does give you a protection layer against unwanted visitors
 
 ## Version Compatibility
 
-Laravel                                                                | l5-very-basic-auth
-:----------------------------------------------------------------------|:----------
-`^5.4`                                                                 | `5.*`
-<code>^6 &#124;&#124; ^7 &#124;&#124; ^8 &#124;&#124; ^9</code>        | `6.*`
+Laravel                                                                                 | l5-very-basic-auth
+:---------------------------------------------------------------------------------------|:----------
+`^5.4`                                                                                  | `5.*` (EOL/deprecated)
+<code>^6 &#124;&#124; ^7 &#124;&#124; ^8 &#124;&#124; ^9 &#124;&#124; ^10</code>        | `6.*` (EOL/deprecated)
+<code>^6 &#124;&#124; ^7 &#124;&#124; ^8 &#124;&#124; ^9 &#124;&#124; ^10</code>        | `7.*`
 
 *The odd versioning is due to breaking changes in the testing framework and PHP versions. `3.x`-releases are  for Laravel 5.4 (PHP 5.6 and up) and `4.x`-releases for Laravel 5.5.*
 
@@ -79,7 +80,7 @@ The file `very_basic_auth.php` will then be copied to your `app/config`-folder â
 
 #### Note
 
-**There is no default password**. Upon installation a random password is set for added security (we don't want everyone to use the same default password). Please publish the packages configuration to have the ability to set a custom password.
+**There is no default password**. Upon installation you will need to set your own username and password. Please publish the packages configuration to have the ability to set these. **If left empty, basic auth will not be active**.
 
 ### Environments
 

--- a/src/Http/Middleware/VeryBasicAuth.php
+++ b/src/Http/Middleware/VeryBasicAuth.php
@@ -38,8 +38,9 @@ class VeryBasicAuth
             $authUsername = $username ?? config('very_basic_auth.user');
             $authPassword = $password ?? config('very_basic_auth.password');
 
-            // Check for credentials
-            if ($request->getUser() !== $authUsername || $request->getPassword() !== $authPassword) {
+            if (!$authUsername && !$authPassword) {
+                return $next($request);
+            } elseif ($request->getUser() !== $authUsername || $request->getPassword() !== $authPassword) {
                 return $this->deniedResponse($request);
             }
         }

--- a/src/VeryBasicAuthServiceProvider.php
+++ b/src/VeryBasicAuthServiceProvider.php
@@ -32,12 +32,6 @@ class VeryBasicAuthServiceProvider extends ServiceProvider
     public function __construct($app)
     {
         $this->config = __DIR__ . '/config.php';
-        $this->stub = __DIR__ . '/config.stub';
-
-        // Check that config-file exists
-        if (!file_exists($this->config)) {
-            $this->createConfig();
-        }
 
         parent::__construct($app);
     }
@@ -78,17 +72,5 @@ class VeryBasicAuthServiceProvider extends ServiceProvider
             ResponseHandler::class,
             config('very_basic_auth.response_handler', DefaultResponseHandler::class)
         );
-    }
-
-    /**
-     * Crates a new config-file with a random password
-     *
-     * @return string bytes written
-     */
-    private function createConfig()
-    {
-        $data = file_get_contents($this->stub);
-        $data = str_replace('%password%', Str::random(8), $data);
-        return file_put_contents($this->config, $data);
     }
 }

--- a/src/config.php
+++ b/src/config.php
@@ -5,10 +5,10 @@
      */
     return [
         // Username
-        'user'              => env('BASIC_AUTH_USERNAME', 'admin'),
+        'user'              => env('BASIC_AUTH_USERNAME', ''),
 
         // Password
-        'password'          => env('BASIC_AUTH_PASSWORD', '%password%'),
+        'password'          => env('BASIC_AUTH_PASSWORD', ''),
 
         // Environments where the middleware is active. Use "*" to protect all envs
         'envs'              => [

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -22,6 +22,5 @@ abstract class TestCase extends OrchestraTestCase
     public static function tearDownAfterClass(): void
     {
         parent::tearDownAfterClass();
-        unlink(__DIR__ . '/../src/config.php');
     }
 }

--- a/tests/VeryBasicAuthTests.php
+++ b/tests/VeryBasicAuthTests.php
@@ -10,6 +10,10 @@ use Olssonm\VeryBasicAuth\Tests\Fixtures\CustomResponseHandler;
 use function Pest\Laravel\get;
 
 beforeEach(function() {
+    // Set default config for testing
+    config()->set('very_basic_auth.user', 'test');
+    config()->set('very_basic_auth.password', 'test');
+
     Route::get('/', fn () => 'ok')->middleware(VeryBasicAuth::class)->name('default');
     Route::get('/test', fn () => 'ok')->middleware(VeryBasicAuth::class);
     Route::get('/inline', fn () => 'ok')->middleware(
@@ -24,6 +28,17 @@ test('basic auth filter is set', function () {
 
 test('config file is installed', function() {
     $this->assertTrue(file_exists(__DIR__ . '/../src/config.php'));
+});
+
+test('request with no credentials and no config passes', function () {
+
+    config()->set('very_basic_auth.user', '');
+    config()->set('very_basic_auth.password', '');
+
+    $response = get('/');
+
+    $this->assertEquals(200, $response->getStatusCode());
+    $this->assertEquals(null, $response->headers->get('WWW-Authenticate'));
 });
 
 test('request with no credentials fails', function() {


### PR DESCRIPTION
This PR fixes an issue where the package tries to write `config.php` on each request; if the web-user doesn't have the permissions to write the file, an error is logged on the system.

Instead, with this update `config.php` is never written, instead a basic stub is used with an empty user/password-combo. When empty, basic auth is inactivated.

See https://github.com/olssonm/l5-very-basic-auth/issues/62.