### PR TITLE
Add Laravel 11 Support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,6 @@ trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,43 +1,48 @@
 name: Run tests
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
 
 jobs:
-    php-tests:
-        runs-on: ubuntu-latest
+  php-tests:
+    runs-on: ubuntu-latest
 
-        strategy:
-            matrix:
-                include:
-                    - php: 8.2
-                      illuminate: ^10.0
-                    - php: 8.1
-                      illuminate: ^9.0
-                    - php: 8.1
-                      illuminate: ^8.0
-                    - php: 8.0
-                      illuminate: ^8.0
-                    - php: 8.0
-                      illuminate: ^7.0
-                    - php: 7.4
-                      illuminate: ^7.0
+    strategy:
+      matrix:
+        php: [8.3, 8.2, 8.1, 8.0]
+        laravel: [11.*, 10.*, 9.*]
+        dependency-version: [prefer-lowest, prefer-stable]
+        exclude:
+          - laravel: 11.*
+            php: 8.1
+          - laravel: 11.*
+            php: 8.0
+          - laravel: 10.*
+            php: 8.0
+          - laravel: 9.*
+            php: 8.3
+          - laravel: 9.*
+            php: 8.2
 
-        name: PHP ${{ matrix.php }} - Illuminate ${{ matrix.illuminate }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-            - name: Setup PHP
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: ${{ matrix.php }}
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip
+          tools: composer:v2
+          coverage: none
 
-            - name: Update composer
-              run: composer self-update --2
+      - name: Install dependencies
+        run: |
+          composer require "illuminate/support:${{ matrix.laravel }}" --no-interaction --no-progress --no-suggest
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-progress
 
-            - name: Install dependencies
-              run: composer require "illuminate/support:${{ matrix.illuminate }}" --no-interaction --no-progress --no-suggest
-
-            - name: Execute tests
-              run: composer test
+      - name: Execute tests
+        run: composer test

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 composer.lock
 .DS_Store
 .phpunit.result.cache
+.phpunit.cache
 phpunit-output

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
     "require-dev": {
         "laravel/helpers": "^1.1",
         "orchestra/testbench": "^7.0 || ^8.0 || ^9.0",
-        "pestphp/pest": "^1.0",
-        "pestphp/pest-plugin-laravel": "^1.2",
+        "pestphp/pest": "^1.0 || ^2.0",
+        "pestphp/pest-plugin-laravel": "^1.2 || ^2.0",
         "phpunit/phpunit": "^9.0 || ^10.5"
     },
     "minimum-stability": "dev",
@@ -43,7 +43,8 @@
     "config": {
         "allow-plugins": {
             "pestphp/pest-plugin": true
-        }
+        },
+        "sort-packages": true
     },
     "extra": {
         "branch-alias": {
@@ -58,6 +59,7 @@
     "scripts": {
         "phpfix": "vendor/bin/phpcbf --standard=\"PSR12\" ./src --ignore=./src/resources/*",
         "phpsniff": "vendor/bin/phpcs --standard=\"PSR12\" ./src --ignore=./src/resources/*",
-        "test": "vendor/bin/pest"
+        "test": "vendor/bin/pest",
+        "lint": "vendor/bin/pint"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,6 @@
     "scripts": {
         "phpfix": "vendor/bin/phpcbf --standard=\"PSR12\" ./src --ignore=./src/resources/*",
         "phpsniff": "vendor/bin/phpcs --standard=\"PSR12\" ./src --ignore=./src/resources/*",
-        "test": "vendor/bin/pest",
-        "lint": "vendor/bin/pint"
+        "test": "vendor/bin/pest"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,13 @@
 {
     "name": "olssonm/l5-very-basic-auth",
     "description": "Laravel stateless HTTP basic auth without the need for a database",
+    "license": "MIT",
     "keywords": [
         "olssonm",
         "laravel",
         "authentication",
         "http basic auth"
     ],
-    "homepage": "https://github.com/olssonm/l5-very-basic-auth",
-    "license": "MIT",
     "authors": [
         {
             "name": "Marcus Olsson",
@@ -16,18 +15,21 @@
             "homepage": "https://marcusolsson.me"
         }
     ],
+    "homepage": "https://github.com/olssonm/l5-very-basic-auth",
     "require": {
-        "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
-        "php": "~7.4|^8.0",
+        "php": "^8.0 || ^8.1 || ^8.2",
+        "illuminate/support": "^9.0 || ^10.0 || ^11.0",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0",
-        "orchestra/testbench": ">=5.0",
         "laravel/helpers": "^1.1",
+        "orchestra/testbench": "^7.0 || ^8.0 || ^9.0",
         "pestphp/pest": "^1.0",
-        "pestphp/pest-plugin-laravel": "^1.2"
+        "pestphp/pest-plugin-laravel": "^1.2",
+        "phpunit/phpunit": "^9.0 || ^10.5"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "Olssonm\\VeryBasicAuth\\": "src"
@@ -38,14 +40,14 @@
             "Olssonm\\VeryBasicAuth\\Tests\\": "tests"
         }
     },
-    "scripts": {
-        "phpsniff": "vendor/bin/phpcs --standard=\"PSR12\" ./src --ignore=./src/resources/*",
-        "phpfix": "vendor/bin/phpcbf --standard=\"PSR12\" ./src --ignore=./src/resources/*",
-        "test": "vendor/bin/pest"
+    "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "6.x-dev"
+            "dev-master": "11.x-dev"
         },
         "laravel": {
             "providers": [
@@ -53,11 +55,9 @@
             ]
         }
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
-    "config": {
-        "allow-plugins": {
-            "pestphp/pest-plugin": true
-        }
+    "scripts": {
+        "phpfix": "vendor/bin/phpcbf --standard=\"PSR12\" ./src --ignore=./src/resources/*",
+        "phpsniff": "vendor/bin/phpcs --standard=\"PSR12\" ./src --ignore=./src/resources/*",
+        "test": "vendor/bin/pest"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,25 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="false"
-         processIsolation="false"
-         stopOnFailure="false"
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    backupGlobals="false"
+    colors="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    cacheDirectory=".phpunit.cache"
+    backupStaticProperties="false"
 >
     <testsuites>
         <testsuite name="Package Test Suite">
-            <file>./tests/VeryBasicAuthTests.php</file>
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <source>
+        <include>
             <directory>src</directory>
-            <exclude>
-                <directory suffix=".blade.php">src</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <directory suffix=".blade.php">src</directory>
+        </exclude>
+    </source>
 </phpunit>

--- a/src/Handlers/DefaultResponseHandler.php
+++ b/src/Handlers/DefaultResponseHandler.php
@@ -13,7 +13,7 @@ class DefaultResponseHandler implements ResponseHandler
             'WWW-Authenticate' => sprintf(
                 'Basic realm="%s", charset="UTF-8"',
                 config('very_basic_auth.realm', 'Basic Auth')
-            )
+            ),
         ];
 
         // View
@@ -22,7 +22,7 @@ class DefaultResponseHandler implements ResponseHandler
         // If the request want's JSON, else view
         if ($request->wantsJson()) {
             return response()->json([
-                'message' => config('very_basic_auth.error_message')
+                'message' => config('very_basic_auth.error_message'),
             ], 401, $header);
         } elseif (isset($view)) {
             return response()->view($view, [], 401)

--- a/src/Http/Middleware/VeryBasicAuth.php
+++ b/src/Http/Middleware/VeryBasicAuth.php
@@ -2,11 +2,10 @@
 
 namespace Olssonm\VeryBasicAuth\Http\Middleware;
 
-use Illuminate\Http\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Closure;
-use Olssonm\VeryBasicAuth\Handlers\DefaultResponseHandler;
+use Illuminate\Http\Request;
 use Olssonm\VeryBasicAuth\Handlers\ResponseHandler;
+use Symfony\Component\HttpFoundation\Response;
 
 class VeryBasicAuth
 {
@@ -20,11 +19,8 @@ class VeryBasicAuth
     /**
      * Handle an incoming request
      *
-     * @param  Request  $request
-     * @param  Closure  $next
-     * @param  mixed    $username
-     * @param  mixed    $password
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @param  mixed  $username
+     * @param  mixed  $password
      */
     public function handle(Request $request, Closure $next, $username = null, $password = null): Response
     {
@@ -38,7 +34,7 @@ class VeryBasicAuth
             $authUsername = $username ?? config('very_basic_auth.user');
             $authPassword = $password ?? config('very_basic_auth.password');
 
-            if (!$authUsername && !$authPassword) {
+            if (! $authUsername && ! $authPassword) {
                 return $next($request);
             } elseif ($request->getUser() !== $authUsername || $request->getPassword() !== $authPassword) {
                 return $this->deniedResponse($request);
@@ -51,7 +47,6 @@ class VeryBasicAuth
     /**
      * Return a error response
      *
-     * @param  \Illuminate\Http\Request $request
      * @return \Illuminate\Http\Response
      */
     private function deniedResponse(Request $request): Response

--- a/src/VeryBasicAuthServiceProvider.php
+++ b/src/VeryBasicAuthServiceProvider.php
@@ -3,7 +3,6 @@
 namespace Olssonm\VeryBasicAuth;
 
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Support\Str;
 use Olssonm\VeryBasicAuth\Handlers\DefaultResponseHandler;
 use Olssonm\VeryBasicAuth\Handlers\ResponseHandler;
 

--- a/src/config.php
+++ b/src/config.php
@@ -1,31 +1,32 @@
 <?php
 
-    /**
-     * Configuration for the "HTTP Very Basic Auth"-middleware
-     */
-    return [
-        // Username
-        'user'              => env('BASIC_AUTH_USERNAME', ''),
+/**
+ * Configuration for the "HTTP Very Basic Auth"-middleware
+ */
 
-        // Password
-        'password'          => env('BASIC_AUTH_PASSWORD', ''),
+return [
+    // Username
+    'user' => env('BASIC_AUTH_USERNAME', ''),
 
-        // Environments where the middleware is active. Use "*" to protect all envs
-        'envs'              => [
-            '*'
-        ],
+    // Password
+    'password' => env('BASIC_AUTH_PASSWORD', ''),
 
-        // Response handler for the error responses
-        'response_handler' => \Olssonm\VeryBasicAuth\Handlers\DefaultResponseHandler::class,
+    // Environments where the middleware is active. Use "*" to protect all envs
+    'envs' => [
+        '*',
+    ],
 
-        // Message to display if the user "opts out"/clicks "cancel"
-        'error_message'     => 'You have to supply your credentials to access this resource.',
+    // Response handler for the error responses
+    'response_handler' => \Olssonm\VeryBasicAuth\Handlers\DefaultResponseHandler::class,
 
-        // Message to display in the auth dialiog in some browsers (mainly Internet Explorer).
-        // Realm is also used to define a "space" that should share credentials.
-        'realm'             => 'Basic Auth',
+    // Message to display if the user "opts out"/clicks "cancel"
+    'error_message' => 'You have to supply your credentials to access this resource.',
 
-        // If you prefer to use a view with your error message you can uncomment "error_view".
-        // This will supersede your default response message
-        // 'error_view'        => 'very_basic_auth::default'
-    ];
+    // Message to display in the auth dialiog in some browsers (mainly Internet Explorer).
+    // Realm is also used to define a "space" that should share credentials.
+    'realm' => 'Basic Auth',
+
+    // If you prefer to use a view with your error message you can uncomment "error_view".
+    // This will supersede your default response message
+    // 'error_view'        => 'very_basic_auth::default'
+];

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,19 @@
 <?php
 
+use Illuminate\Support\Facades\Route;
+use Olssonm\VeryBasicAuth\Http\Middleware\VeryBasicAuth;
 use Olssonm\VeryBasicAuth\Tests\TestCase;
 
-uses(TestCase::class)->in(__DIR__);
+uses(TestCase::class)
+    ->beforeEach(function () {
+        // Set default config for testing
+        config()->set('very_basic_auth.user', 'test');
+        config()->set('very_basic_auth.password', 'test');
+    
+        Route::get('/', fn () => 'ok')->middleware(VeryBasicAuth::class)->name('default');
+        Route::get('/test', fn () => 'ok')->middleware(VeryBasicAuth::class);
+        Route::get('/inline', fn () => 'ok')->middleware(
+            sprintf('auth.very_basic:%s,%s', config('very_basic_auth.user'), config('very_basic_auth.password'))
+        )->name('inline');
+    })
+    ->in(__DIR__);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,3 @@
 <?php
 
-namespace Olssonm\VeryBasicAuth\Tests;
-
 uses(TestCase::class)->in(__DIR__);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,3 +1,5 @@
 <?php
 
+use Olssonm\VeryBasicAuth\Tests\TestCase;
+
 uses(TestCase::class)->in(__DIR__);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,7 +15,7 @@ abstract class TestCase extends OrchestraTestCase
     protected function getPackageProviders($app)
     {
         return [
-            VeryBasicAuthServiceProvider::class
+            VeryBasicAuthServiceProvider::class,
         ];
     }
 

--- a/tests/VeryBasicAuthTest.php
+++ b/tests/VeryBasicAuthTest.php
@@ -31,7 +31,7 @@ test('request with no credentials fails', function () {
 
     expect($response->getStatusCode())->toEqual(401);
     expect($response->headers->get('WWW-Authenticate'))->toEqual(sprintf('Basic realm="%s", charset="UTF-8"', config('very_basic_auth.realm')));
-    epexct($response->getContent())->toEqual(config('very_basic_auth.error_message'));
+    expect($response->getContent())->toEqual(config('very_basic_auth.error_message'));
 });
 
 test('request with incorrect credentials fails - text/html', function () {

--- a/tests/VeryBasicAuthTest.php
+++ b/tests/VeryBasicAuthTest.php
@@ -30,9 +30,8 @@ test('request with no credentials fails', function () {
     $response = get('/');
 
     expect($response->getStatusCode())->toEqual(401);
-    
-    $this->assertEquals(sprintf('Basic realm="%s", charset="UTF-8"', config('very_basic_auth.realm')), $response->headers->get('WWW-Authenticate'));
-    $this->assertEquals(config('very_basic_auth.error_message'), $response->getContent());
+    expect($response->headers->get('WWW-Authenticate'))->toEqual(sprintf('Basic realm="%s", charset="UTF-8"', config('very_basic_auth.realm')));
+    epexct($response->getContent())->toEqual(config('very_basic_auth.error_message'));
 });
 
 test('request with incorrect credentials fails - text/html', function () {
@@ -41,10 +40,10 @@ test('request with incorrect credentials fails - text/html', function () {
         'PHP_AUTH_PW' => str_random(20),
     ])->get('/');
 
-    $this->assertEquals(401, $response->getStatusCode());
-    $this->assertEquals('text/html; charset=UTF-8', $response->headers->get('content-type'));
-    $this->assertEquals(sprintf('Basic realm="%s", charset="UTF-8"', config('very_basic_auth.realm')), $response->headers->get('WWW-Authenticate'));
-    $this->assertEquals(config('very_basic_auth.error_message'), $response->getContent());
+    expect($response->getStatusCode())->toEqual(401);
+    expect($response->headers->get('content-type'))->toEqual('text/html; charset=UTF-8');
+    expect($response->headers->get('WWW-Authenticate'))->toEqual(sprintf('Basic realm="%s", charset="UTF-8"', config('very_basic_auth.realm')));
+    expect($response->getContent())->toEqual(config('very_basic_auth.error_message'));
 });
 
 test('request with incorrect credentials fails - json', function () {
@@ -56,11 +55,11 @@ test('request with incorrect credentials fails - json', function () {
 
     $content = json_decode($response->getContent());
 
-    $this->assertEquals(401, $response->getStatusCode());
-    $this->assertEquals('application/json', $response->headers->get('content-type'));
-    $this->assertEquals(json_last_error(), JSON_ERROR_NONE);
-    $this->assertEquals(config('very_basic_auth.error_message'), $content->message);
-    $this->assertEquals(sprintf('Basic realm="%s", charset="UTF-8"', config('very_basic_auth.realm')), $response->headers->get('WWW-Authenticate'));
+    expect($response->getStatusCode())->toEqual(401);
+    expect($response->headers->get('content-type'))->toEqual('application/json');
+    expect(json_last_error())->toEqual(JSON_ERROR_NONE);
+    expect($content->message)->toEqual(config('very_basic_auth.error_message'));
+    expect($response->headers->get('WWW-Authenticate'))->toEqual(sprintf('Basic realm="%s", charset="UTF-8"', config('very_basic_auth.realm')));
 });
 
 test('request with incorrect credentials fails - view', function () {
@@ -72,9 +71,10 @@ test('request with incorrect credentials fails - view', function () {
         'PHP_AUTH_PW' => str_random(20),
     ])->get('/');
 
-    $this->assertEquals(401, $response->getStatusCode());
-    $this->assertEquals('text/html; charset=UTF-8', $response->headers->get('content-type'));
-    $this->assertEquals(sprintf('Basic realm="%s", charset="UTF-8"', config('very_basic_auth.realm')), $response->headers->get('WWW-Authenticate'));
+    expect($response->getStatusCode())->toEqual(401);
+    expect($response->headers->get('content-type'))->toEqual('text/html; charset=UTF-8');
+    expect($response->headers->get('WWW-Authenticate'))->toEqual(sprintf('Basic realm="%s", charset="UTF-8"', config('very_basic_auth.realm')));
+
     $this->assertStringContainsStringIgnoringCase('This is the default view for the olssonm/l5-very-basic-auth-package', $response->getContent());
 });
 

--- a/tests/VeryBasicAuthTest.php
+++ b/tests/VeryBasicAuthTest.php
@@ -1,24 +1,11 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
 use Olssonm\VeryBasicAuth\Handlers\DefaultResponseHandler;
 use Olssonm\VeryBasicAuth\Handlers\ResponseHandler;
 use Olssonm\VeryBasicAuth\Http\Middleware\VeryBasicAuth;
 use Olssonm\VeryBasicAuth\Tests\Fixtures\CustomResponseHandler;
 
 use function Pest\Laravel\get;
-
-beforeEach(function () {
-    // Set default config for testing
-    config()->set('very_basic_auth.user', 'test');
-    config()->set('very_basic_auth.password', 'test');
-
-    Route::get('/', fn () => 'ok')->middleware(VeryBasicAuth::class)->name('default');
-    Route::get('/test', fn () => 'ok')->middleware(VeryBasicAuth::class);
-    Route::get('/inline', fn () => 'ok')->middleware(
-        sprintf('auth.very_basic:%s,%s', config('very_basic_auth.user'), config('very_basic_auth.password'))
-    )->name('inline');
-});
 
 test('basic auth filter is set', function () {
     expect(in_array(VeryBasicAuth::class, $this->app->router->getMiddleware()))->toBeTrue();
@@ -30,7 +17,6 @@ test('config file is installed', function () {
 });
 
 test('request with no credentials and no config passes', function () {
-
     config()->set('very_basic_auth.user', '');
     config()->set('very_basic_auth.password', '');
 
@@ -43,7 +29,8 @@ test('request with no credentials and no config passes', function () {
 test('request with no credentials fails', function () {
     $response = get('/');
 
-    $this->assertEquals(401, $response->getStatusCode());
+    expect($response->getStatusCode())->toEqual(401);
+    
     $this->assertEquals(sprintf('Basic realm="%s", charset="UTF-8"', config('very_basic_auth.realm')), $response->headers->get('WWW-Authenticate'));
     $this->assertEquals(config('very_basic_auth.error_message'), $response->getContent());
 });

--- a/tests/VeryBasicAuthTest.php
+++ b/tests/VeryBasicAuthTest.php
@@ -6,7 +6,7 @@ use Olssonm\VeryBasicAuth\Http\Middleware\VeryBasicAuth;
 use Olssonm\VeryBasicAuth\Tests\Fixtures\CustomResponseHandler;
 
 use function Pest\Laravel\get;
-use function Pest\Laravel\withHeader;
+use function Pest\Laravel\withHeaders;
 
 test('basic auth filter is set', function () {
     expect(in_array(VeryBasicAuth::class, $this->app->router->getMiddleware()))->toBeTrue();
@@ -36,7 +36,7 @@ test('request with no credentials fails', function () {
 });
 
 test('request with incorrect credentials fails - text/html', function () {
-    $response = withHeader([
+    $response = withHeaders([
         'PHP_AUTH_USER' => str_random(20),
         'PHP_AUTH_PW' => str_random(20),
     ])->get('/');
@@ -48,7 +48,7 @@ test('request with incorrect credentials fails - text/html', function () {
 });
 
 test('request with incorrect credentials fails - json', function () {
-    $response = withHeader([
+    $response = withHeaders([
         'PHP_AUTH_USER' => str_random(20),
         'PHP_AUTH_PW' => str_random(20),
         'Accept' => 'application/json',
@@ -66,7 +66,7 @@ test('request with incorrect credentials fails - json', function () {
 test('request with incorrect credentials fails - view', function () {
     config()->set('very_basic_auth.error_view', 'very_basic_auth::default');
 
-    $response = withHeader([
+    $response = withHeaders([
         'PHP_AUTH_USER' => str_random(20),
         'PHP_AUTH_PW' => str_random(20),
     ])->get('/');
@@ -79,7 +79,7 @@ test('request with incorrect credentials fails - view', function () {
 });
 
 test('request with correct credentials passes', function () {
-    $response = withHeader([
+    $response = withHeaders([
         'PHP_AUTH_USER' => config('very_basic_auth.user'),
         'PHP_AUTH_PW' => config('very_basic_auth.password'),
     ])->get('/');
@@ -103,7 +103,7 @@ test('environments', function () {
 });
 
 test('request with incorrect inline credentials fails', function () {
-    $response = withHeader([
+    $response = withHeaders([
         'PHP_AUTH_USER' => str_random(20),
         'PHP_AUTH_PW' => str_random(20),
     ])->get('/inline');
@@ -113,7 +113,7 @@ test('request with incorrect inline credentials fails', function () {
 });
 
 test('request with correct inline credentials passes', function () {
-    $response = withHeader([
+    $response = withHeaders([
         'PHP_AUTH_USER' => config('very_basic_auth.user'),
         'PHP_AUTH_PW' => config('very_basic_auth.password'),
     ])->get('/inline');

--- a/tests/VeryBasicAuthTest.php
+++ b/tests/VeryBasicAuthTest.php
@@ -6,6 +6,7 @@ use Olssonm\VeryBasicAuth\Http\Middleware\VeryBasicAuth;
 use Olssonm\VeryBasicAuth\Tests\Fixtures\CustomResponseHandler;
 
 use function Pest\Laravel\get;
+use function Pest\Laravel\withHeader;
 
 test('basic auth filter is set', function () {
     expect(in_array(VeryBasicAuth::class, $this->app->router->getMiddleware()))->toBeTrue();
@@ -35,7 +36,7 @@ test('request with no credentials fails', function () {
 });
 
 test('request with incorrect credentials fails - text/html', function () {
-    $response = $this->withHeaders([
+    $response = withHeaders([
         'PHP_AUTH_USER' => str_random(20),
         'PHP_AUTH_PW' => str_random(20),
     ])->get('/');
@@ -47,7 +48,7 @@ test('request with incorrect credentials fails - text/html', function () {
 });
 
 test('request with incorrect credentials fails - json', function () {
-    $response = $this->withHeaders([
+    $response = withHeaders([
         'PHP_AUTH_USER' => str_random(20),
         'PHP_AUTH_PW' => str_random(20),
         'Accept' => 'application/json',
@@ -63,10 +64,9 @@ test('request with incorrect credentials fails - json', function () {
 });
 
 test('request with incorrect credentials fails - view', function () {
-
     config()->set('very_basic_auth.error_view', 'very_basic_auth::default');
 
-    $response = $this->withHeaders([
+    $response = withHeaders([
         'PHP_AUTH_USER' => str_random(20),
         'PHP_AUTH_PW' => str_random(20),
     ])->get('/');
@@ -79,47 +79,47 @@ test('request with incorrect credentials fails - view', function () {
 });
 
 test('request with correct credentials passes', function () {
-    $response = $this->withHeaders([
+    $response = withHeaders([
         'PHP_AUTH_USER' => config('very_basic_auth.user'),
         'PHP_AUTH_PW' => config('very_basic_auth.password'),
     ])->get('/');
 
-    $this->assertEquals(200, $response->getStatusCode());
-    $this->assertEquals('ok', $response->getContent());
+    expect($response->getStatusCode())->toEqual(200);
+    expect($response->getContent())->toEqual('ok');
 });
 
 test('environments', function () {
     config()->set('very_basic_auth.envs', ['production']);
-    $this->get('/')->assertStatus(200);
+    get('/')->assertStatus(200);
 
     config()->set('very_basic_auth.envs', ['local']);
-    $this->get('/')->assertStatus(200);
+    get('/')->assertStatus(200);
 
     config()->set('very_basic_auth.envs', ['*']);
-    $this->get('/')->assertStatus(401);
+    get('/')->assertStatus(401);
 
     config()->set('very_basic_auth.envs', ['testing']);
-    $this->get('/')->assertStatus(401);
+    get('/')->assertStatus(401);
 });
 
 test('request with incorrect inline credentials fails', function () {
-    $response = $this->withHeaders([
+    $response = withHeaders([
         'PHP_AUTH_USER' => str_random(20),
         'PHP_AUTH_PW' => str_random(20),
     ])->get('/inline');
 
-    $this->assertEquals(401, $response->getStatusCode());
-    $this->assertEquals(config('very_basic_auth.error_message'), $response->getContent());
+    expect($response->getStatusCode())->toEqual(401);
+    expect($response->getContent())->toEqual(config('very_basic_auth.error_message'));
 });
 
 test('request with correct inline credentials passes', function () {
-    $response = $this->withHeaders([
+    $response = withHeaders([
         'PHP_AUTH_USER' => config('very_basic_auth.user'),
         'PHP_AUTH_PW' => config('very_basic_auth.password'),
     ])->get('/inline');
 
-    $this->assertEquals(200, $response->getStatusCode());
-    $this->assertEquals('ok', $response->getContent());
+    expect($response->getStatusCode())->toEqual(200);
+    expect($response->getContent())->toEqual('ok');
 });
 
 test('test response handlers', function () {
@@ -131,8 +131,8 @@ test('test response handlers', function () {
 
     $response = get('/test');
 
-    $this->assertEquals(401, $response->getStatusCode());
-    $this->assertEquals('Custom response', $response->getContent());
+    expect($response->getStatusCode())->toEqual(401);
+    expect($response->getContent())->toEqual('Custom reponse');
 
     // Default response handler
     app()->bind(
@@ -142,6 +142,6 @@ test('test response handlers', function () {
 
     $response = get('/test');
 
-    $this->assertEquals(401, $response->getStatusCode());
-    $this->assertEquals(config('very_basic_auth.error_message'), $response->getContent());
+    expect($response->getStatusCode())->toEqual(401);
+    expect($response->getContent())->toEqual(config('very_basic_auth.error_message'));
 });

--- a/tests/VeryBasicAuthTest.php
+++ b/tests/VeryBasicAuthTest.php
@@ -36,7 +36,7 @@ test('request with no credentials fails', function () {
 });
 
 test('request with incorrect credentials fails - text/html', function () {
-    $response = withHeaders([
+    $response = withHeader([
         'PHP_AUTH_USER' => str_random(20),
         'PHP_AUTH_PW' => str_random(20),
     ])->get('/');
@@ -48,7 +48,7 @@ test('request with incorrect credentials fails - text/html', function () {
 });
 
 test('request with incorrect credentials fails - json', function () {
-    $response = withHeaders([
+    $response = withHeader([
         'PHP_AUTH_USER' => str_random(20),
         'PHP_AUTH_PW' => str_random(20),
         'Accept' => 'application/json',
@@ -66,7 +66,7 @@ test('request with incorrect credentials fails - json', function () {
 test('request with incorrect credentials fails - view', function () {
     config()->set('very_basic_auth.error_view', 'very_basic_auth::default');
 
-    $response = withHeaders([
+    $response = withHeader([
         'PHP_AUTH_USER' => str_random(20),
         'PHP_AUTH_PW' => str_random(20),
     ])->get('/');
@@ -79,7 +79,7 @@ test('request with incorrect credentials fails - view', function () {
 });
 
 test('request with correct credentials passes', function () {
-    $response = withHeaders([
+    $response = withHeader([
         'PHP_AUTH_USER' => config('very_basic_auth.user'),
         'PHP_AUTH_PW' => config('very_basic_auth.password'),
     ])->get('/');
@@ -103,7 +103,7 @@ test('environments', function () {
 });
 
 test('request with incorrect inline credentials fails', function () {
-    $response = withHeaders([
+    $response = withHeader([
         'PHP_AUTH_USER' => str_random(20),
         'PHP_AUTH_PW' => str_random(20),
     ])->get('/inline');
@@ -113,7 +113,7 @@ test('request with incorrect inline credentials fails', function () {
 });
 
 test('request with correct inline credentials passes', function () {
-    $response = withHeaders([
+    $response = withHeader([
         'PHP_AUTH_USER' => config('very_basic_auth.user'),
         'PHP_AUTH_PW' => config('very_basic_auth.password'),
     ])->get('/inline');
@@ -132,7 +132,7 @@ test('test response handlers', function () {
     $response = get('/test');
 
     expect($response->getStatusCode())->toEqual(401);
-    expect($response->getContent())->toEqual('Custom reponse');
+    expect($response->getContent())->toEqual('Custom response');
 
     // Default response handler
     app()->bind(

--- a/tests/VeryBasicAuthTests.php
+++ b/tests/VeryBasicAuthTests.php
@@ -21,12 +21,12 @@ beforeEach(function () {
 });
 
 test('basic auth filter is set', function () {
-    $this->assertTrue(in_array(VeryBasicAuth::class, $this->app->router->getMiddleware()));
-    $this->assertTrue(array_key_exists('auth.very_basic', $this->app->router->getMiddleware()));
+    expect(in_array(VeryBasicAuth::class, $this->app->router->getMiddleware()))->toBeTrue();
+    expect(array_key_exists('auth.very_basic', $this->app->router->getMiddleware()));
 });
 
 test('config file is installed', function () {
-    $this->assertTrue(file_exists(__DIR__.'/../src/config.php'));
+    expect(file_exists(__DIR__.'/../src/config.php'))->toBeTrue();
 });
 
 test('request with no credentials and no config passes', function () {
@@ -36,8 +36,8 @@ test('request with no credentials and no config passes', function () {
 
     $response = get('/');
 
-    $this->assertEquals(200, $response->getStatusCode());
-    $this->assertEquals(null, $response->headers->get('WWW-Authenticate'));
+    expect($response->getStatusCode())->toEqual(200);
+    expect($response->headers->get('WWW-Authenticate'))->toEqual(null);
 });
 
 test('request with no credentials fails', function () {

--- a/tests/VeryBasicAuthTests.php
+++ b/tests/VeryBasicAuthTests.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Route;
 use Olssonm\VeryBasicAuth\Handlers\DefaultResponseHandler;
 use Olssonm\VeryBasicAuth\Handlers\ResponseHandler;
@@ -9,7 +8,7 @@ use Olssonm\VeryBasicAuth\Tests\Fixtures\CustomResponseHandler;
 
 use function Pest\Laravel\get;
 
-beforeEach(function() {
+beforeEach(function () {
     // Set default config for testing
     config()->set('very_basic_auth.user', 'test');
     config()->set('very_basic_auth.password', 'test');
@@ -26,8 +25,8 @@ test('basic auth filter is set', function () {
     $this->assertTrue(array_key_exists('auth.very_basic', $this->app->router->getMiddleware()));
 });
 
-test('config file is installed', function() {
-    $this->assertTrue(file_exists(__DIR__ . '/../src/config.php'));
+test('config file is installed', function () {
+    $this->assertTrue(file_exists(__DIR__.'/../src/config.php'));
 });
 
 test('request with no credentials and no config passes', function () {
@@ -41,7 +40,7 @@ test('request with no credentials and no config passes', function () {
     $this->assertEquals(null, $response->headers->get('WWW-Authenticate'));
 });
 
-test('request with no credentials fails', function() {
+test('request with no credentials fails', function () {
     $response = get('/');
 
     $this->assertEquals(401, $response->getStatusCode());
@@ -52,7 +51,7 @@ test('request with no credentials fails', function() {
 test('request with incorrect credentials fails - text/html', function () {
     $response = $this->withHeaders([
         'PHP_AUTH_USER' => str_random(20),
-		'PHP_AUTH_PW' => str_random(20)
+        'PHP_AUTH_PW' => str_random(20),
     ])->get('/');
 
     $this->assertEquals(401, $response->getStatusCode());
@@ -65,7 +64,7 @@ test('request with incorrect credentials fails - json', function () {
     $response = $this->withHeaders([
         'PHP_AUTH_USER' => str_random(20),
         'PHP_AUTH_PW' => str_random(20),
-        'Accept' => 'application/json'
+        'Accept' => 'application/json',
     ])->get('/');
 
     $content = json_decode($response->getContent());
@@ -83,7 +82,7 @@ test('request with incorrect credentials fails - view', function () {
 
     $response = $this->withHeaders([
         'PHP_AUTH_USER' => str_random(20),
-        'PHP_AUTH_PW' => str_random(20)
+        'PHP_AUTH_PW' => str_random(20),
     ])->get('/');
 
     $this->assertEquals(401, $response->getStatusCode());
@@ -95,7 +94,7 @@ test('request with incorrect credentials fails - view', function () {
 test('request with correct credentials passes', function () {
     $response = $this->withHeaders([
         'PHP_AUTH_USER' => config('very_basic_auth.user'),
-        'PHP_AUTH_PW' => config('very_basic_auth.password')
+        'PHP_AUTH_PW' => config('very_basic_auth.password'),
     ])->get('/');
 
     $this->assertEquals(200, $response->getStatusCode());
@@ -119,7 +118,7 @@ test('environments', function () {
 test('request with incorrect inline credentials fails', function () {
     $response = $this->withHeaders([
         'PHP_AUTH_USER' => str_random(20),
-        'PHP_AUTH_PW' => str_random(20)
+        'PHP_AUTH_PW' => str_random(20),
     ])->get('/inline');
 
     $this->assertEquals(401, $response->getStatusCode());
@@ -129,7 +128,7 @@ test('request with incorrect inline credentials fails', function () {
 test('request with correct inline credentials passes', function () {
     $response = $this->withHeaders([
         'PHP_AUTH_USER' => config('very_basic_auth.user'),
-        'PHP_AUTH_PW' => config('very_basic_auth.password')
+        'PHP_AUTH_PW' => config('very_basic_auth.password'),
     ])->get('/inline');
 
     $this->assertEquals(200, $response->getStatusCode());


### PR DESCRIPTION
Add support for Laravel 11 and drops support for Laravel 7 and Laravel 8. Updated Github Workflow to test against the various PHP and Laravel versions. Updated test to use PEST functions.