### PR TITLE
Drop support for EOL Laravel versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,19 +10,13 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.4, 8.3, 8.2, 8.1]
-        laravel: ['10.*', '11.*', '12.*', '13.*']
+        php: [8.5, 8.4, 8.3, 8.2]
+        laravel: ['12.*', '13.*']
         exclude:
-          - php: 8.1
-            laravel: 11.*
-          - php: 8.4
-            laravel: 10.*
-          - laravel: 12.*
-            php: 8.1
           - laravel: 13.*
             php: 8.2
-          - laravel: 13.*
-            php: 8.1
+          - laravel: 12.*
+            php: 8.5
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -17,16 +17,16 @@
     ],
     "homepage": "https://github.com/olssonm/l5-very-basic-auth",
     "require": {
-        "php": "^8.0 || ^8.1 || ^8.2",
-        "illuminate/support": "^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0"
+        "php": "^8.2",
+        "illuminate/support": "^12.0 || ^13.0"
     },
     "require-dev": {
         "laravel/helpers": "^1.1",
-        "orchestra/testbench": "^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0",
-        "pestphp/pest": "^1.0 || ^2.0 || ^3.7 || ^4.4",
-        "pestphp/pest-plugin-laravel": "^1.2 || ^2.0 || ^3.1 || ^4.1",
+        "orchestra/testbench": "^10.0 || ^11.0",
+        "pestphp/pest": "^3.7 || ^4.4",
+        "pestphp/pest-plugin-laravel": "^3.1 || ^4.1",
         "phpstan/phpstan": "^2.0",
-        "phpunit/phpunit": "^9.0 || ^10.5 || ^11.5.3 || ^12.5.12",
+        "phpunit/phpunit": "^11.5.3 || ^12.5.12",
         "squizlabs/php_codesniffer": "^3.5 || ^4.0"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Drop support for EOL Laravel versions (9, 10, 11).

Updates composer requirements accordingly. PHP minimum bumped to 8.2 to match Laravel 12's requirement. CI matrix updated to reflect the reduced support matrix.